### PR TITLE
Resolves #1 Add initial graalvm-pi-builder container setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md — graalvm-pi-builder
+
+## Image purpose
+
+`ghcr.io/lofthouse-dev/graalvm-pi-builder` is an aarch64 container image built on
+`debian:bookworm` (same glibc as Raspberry Pi OS 12). It bundles:
+
+- GraalVM Community Edition (Java 25) with `native-image`
+- `libi2c-dev` — I2C headers for Pi hardware FFM bindings
+- JBang — for Java script and one-shot native-image workloads
+
+## Image name and tags
+
+| Variable | Value |
+|---|---|
+| Image | `ghcr.io/lofthouse-dev/graalvm-pi-builder` |
+| Mutable tag | `bookworm-graal25` |
+| Immutable tag | `bookworm-25.0.2` |
+| Dev/local tag | `latest` |
+
+## Current versions
+
+| Tool | Version |
+|---|---|
+| GraalVM CE | 25.0.2 |
+| JBang | 0.125.0 |
+
+## Build commands
+
+```bash
+make build-dev      # build :latest — dev iteration
+make build          # build :bookworm-graal25
+make build-release  # build :bookworm-graal25 + :bookworm-25.0.2
+make setup-podman   # install QEMU aarch64 binfmt (Arch Linux only)
+```
+
+## Future work
+
+- GitHub Actions PR workflow: build test (no push)
+- GitHub Actions tag push workflow: build + push to GHCR

--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,9 @@ ARG GRAALVM_VERSION=25.0.2
 ARG JBANG_VERSION=0.125.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget ca-certificates unzip libi2c-dev \
+    wget ca-certificates unzip \
+    gcc libc-dev zlib1g-dev \
+    libi2c-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN wget -q \

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,29 @@
+FROM --platform=linux/arm64 debian:bookworm
+
+ARG GRAALVM_VERSION=25.0.2
+ARG JBANG_VERSION=0.125.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget ca-certificates unzip libi2c-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -q \
+  "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAALVM_VERSION}/graalvm-community-jdk-${GRAALVM_VERSION}_linux-aarch64_bin.tar.gz" \
+  -O /tmp/graalvm.tar.gz \
+  && mkdir -p /opt/graalvm \
+  && tar -xzf /tmp/graalvm.tar.gz -C /opt/graalvm --strip-components=1 \
+  && rm /tmp/graalvm.tar.gz
+
+ENV JAVA_HOME=/opt/graalvm
+ENV PATH="$JAVA_HOME/bin:$PATH"
+
+RUN wget -q \
+  "https://github.com/jbangdev/jbang/releases/download/v${JBANG_VERSION}/jbang-${JBANG_VERSION}.zip" \
+  -O /tmp/jbang.zip \
+  && unzip -q /tmp/jbang.zip -d /tmp/jbang-extract \
+  && mv /tmp/jbang-extract/jbang-${JBANG_VERSION} /opt/jbang \
+  && rm -rf /tmp/jbang.zip /tmp/jbang-extract
+
+ENV PATH="/opt/jbang/bin:$PATH"
+
+WORKDIR /build

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,178 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of developing and
+      discussing the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combined Contribution(s) and the Work.
+      If You institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work or
+      any Contribution embodied within the Work constitutes patent or
+      contributory patent infringement, then any patent licenses granted to
+      You under this License for that Work shall terminate as of the date
+      such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the
+          License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Derivative Works, in terms that are not inconsistent with this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any conditions of title,
+      MERCHANTIBILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely
+      responsible for determining the appropriateness of using or
+      redistributing the Work and assume any risks associated with Your
+      exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (even if such Contributor has been advised of the possibility
+      of such damages).
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may offer only
+      conditions consistent with this License and liability that are
+      consistent with the obligations set forth in this License.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Lofthouse Dev
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+IMAGE     = ghcr.io/lofthouse-dev/graalvm-pi-builder
+GRAALVM   = 25.0.2
+MUTABLE   = bookworm-graal25
+IMMUTABLE = bookworm-$(GRAALVM)
+SNAPSHOT  = bookworm-$(GRAALVM)-$(shell date +%Y%m%d%H%M)
+LOCAL     = latest
+
+.DEFAULT_GOAL := help
+
+.PHONY: help build-dev build build-release setup-podman
+
+help:
+	@echo "Targets:"
+	@echo "  build-dev      Build tagged $(IMAGE):$(LOCAL) (dev iteration)"
+	@echo "  build          Build tagged $(IMAGE):$(MUTABLE)"
+	@echo "  build-release  Build and tag as $(IMAGE):$(MUTABLE), $(IMAGE):$(IMMUTABLE),"
+	@echo "                 and $(IMAGE):$(SNAPSHOT)"
+	@echo "  setup-podman   Install QEMU aarch64 binfmt support (Arch Linux)"
+
+build-dev:
+	podman build --platform linux/arm64 -t $(IMAGE):$(LOCAL) .
+
+build:
+	podman build --platform linux/arm64 -t $(IMAGE):$(MUTABLE) .
+
+build-release:
+	podman build --platform linux/arm64 \
+	  -t $(IMAGE):$(MUTABLE) \
+	  -t $(IMAGE):$(IMMUTABLE) \
+	  -t $(IMAGE):$(SNAPSHOT) \
+	  .
+
+setup-podman:
+	scripts/setup/setup-podman.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# graalvm-pi-builder
+
+A general-purpose aarch64 GraalVM build environment matched to Raspberry Pi OS 12 (Debian bookworm).
+
+## What this image is
+
+`ghcr.io/lofthouse-dev/graalvm-pi-builder` is a container image built for `linux/arm64` on top of
+`debian:bookworm` — the same glibc base as Raspberry Pi OS 12. It bundles:
+
+- **GraalVM Community Edition** (Java 25) with `native-image`
+- **libi2c-dev** — I2C headers for compiling FFM bindings against Pi hardware
+- **JBang** — for running Java scripts and one-shot native-image workloads
+
+The image is version-pinned and reproducible, making it suitable for local development via
+Podman + QEMU and for CI on native arm64 runners.
+
+## Use cases
+
+- Capturing FFM reachability metadata with the `native-image-agent`
+- Generating CAP caches (`-H:+NewCAPCache`) for GraalVM native-image builds
+- Building GraalVM native binaries targeting aarch64 / Pi OS 12
+
+## Image tags
+
+| Tag | Type | Meaning |
+|---|---|---|
+| `bookworm-graal25` | Mutable | Latest GraalVM 25.x on Debian bookworm; updated in place |
+| `bookworm-25.0.2` | Immutable | Pinned to a specific GraalVM release |
+
+Use the mutable tag to track updates; use the immutable tag to pin a known-good build.
+
+## Prerequisites
+
+- [Podman](https://podman.io/)
+- On x86_64 hosts: QEMU aarch64 binfmt support (`make setup-podman`)
+
+## Build
+
+```bash
+# One-time QEMU setup (Arch Linux x86_64 hosts only)
+make setup-podman
+
+# Dev iteration — builds tagged :latest
+make build-dev
+
+# Named mutable release tag
+make build
+
+# Both mutable and immutable tags
+make build-release
+```
+
+`build-dev` is the iteration target during development. `build` and `build-release` are for
+publishing to GHCR.
+
+## Updating GraalVM
+
+1. Change `GRAALVM` in `Makefile`
+2. Change the `ARG GRAALVM_VERSION` default in `Containerfile`
+3. Run `make build-release`
+
+## Using the image
+
+As a base image:
+
+```dockerfile
+FROM ghcr.io/lofthouse-dev/graalvm-pi-builder:bookworm-graal25
+```
+
+As a container for JBang or native-image workloads:
+
+```bash
+podman run --rm -v $(pwd):/build:z ghcr.io/lofthouse-dev/graalvm-pi-builder:bookworm-graal25 \
+  native-image -jar myapp.jar
+```
+
+## License
+
+Apache License 2.0 — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A general-purpose aarch64 GraalVM build environment matched to Raspberry Pi OS 1
 `debian:bookworm` — the same glibc base as Raspberry Pi OS 12. It bundles:
 
 - **GraalVM Community Edition** (Java 25) with `native-image`
+- **gcc, libc-dev, zlib1g-dev** — native toolchain required by `native-image` to link binaries
 - **libi2c-dev** — I2C headers for compiling FFM bindings against Pi hardware
 - **JBang** — for running Java scripts and one-shot native-image workloads
 

--- a/scripts/setup/setup-podman.sh
+++ b/scripts/setup/setup-podman.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# One-time setup: install QEMU user-mode emulation packages on Arch Linux
+# so that Podman can run arm64 containers via binfmt_misc.
+set -euo pipefail
+
+echo "==> Installing QEMU user-static packages..."
+sudo pacman -S --noconfirm qemu-user-static qemu-user-static-binfmt
+
+echo "==> Restarting systemd-binfmt to register QEMU handlers..."
+sudo systemctl restart systemd-binfmt
+
+echo "==> Verifying qemu-aarch64 binfmt handler..."
+BINFMT_ENTRY=/proc/sys/fs/binfmt_misc/qemu-aarch64
+if [ -f "$BINFMT_ENTRY" ]; then
+    echo "    OK — $BINFMT_ENTRY exists"
+    cat "$BINFMT_ENTRY"
+else
+    echo "ERROR: $BINFMT_ENTRY not found."
+    echo "  Check that qemu-user-static-binfmt is installed and systemd-binfmt ran."
+    exit 1
+fi
+
+echo ""
+echo "==> Podman QEMU setup complete."
+echo "    Run 'make build-dev' to build the container image."


### PR DESCRIPTION
Introduce a Podman-based container image (`debian:bookworm` aarch64) with:
- GraalVM CE 25.0.2 + native-image
- libi2c-dev for Pi hardware FFM bindings
- JBang for Java scripts and workloads

Implement three-tier tagging strategy:
- `bookworm-graal25` (mutable) — tracks latest GraalVM 25.x
- `bookworm-25.0.2` (GraalVM-pinned, apt-mutable) — stable release, rebuilds for CVEs
- `bookworm-25.0.2-YYYYMMDDHHMM` (snapshot) — fully pinned state at build time

Includes Makefile targets (build-dev, build, build-release), setup-podman.sh for QEMU on Arch Linux, documentation, and Apache 2.0 license.